### PR TITLE
[RE-131] | modify UserResponse ObjectType & add ErrorFactory Util added

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,5 +45,6 @@ module.exports = {
     "no-unused-vars": "warn",
     "no-console": "warn",
     "click-events-have-key-events": "off",
+    "max-classes-per-file": "off",
   },
 };

--- a/src/resolvers/types/UserResponse.ts
+++ b/src/resolvers/types/UserResponse.ts
@@ -1,14 +1,34 @@
 import { Field, ObjectType } from "type-graphql";
-import { ApolloError } from "apollo-server-express";
 import User from "../../entities/User";
+
+// @ObjectType()
+// class Args {
+//   @Field()
+//   name: string;
+
+//   @Field()
+//   message: string;
+// }
+
+@ObjectType()
+export class FieldError {
+  @Field()
+  code: string;
+
+  @Field()
+  message: string;
+
+  @Field()
+  field?: string;
+}
 
 @ObjectType()
 export class UserResponse {
-  @Field(() => [ApolloError], { nullable: true })
-  errors?: ApolloError[];
-
   @Field(() => User, { nullable: true })
   user?: User;
+
+  @Field(() => FieldError, { nullable: true })
+  error?: FieldError;
 }
 
 export default UserResponse;

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -3,10 +3,13 @@ import { Strategy as GoogleStrategy } from "passport-google-oauth20";
 import { Strategy as GitHubStrategy } from "passport-github2";
 import { GraphQLLocalStrategy } from "graphql-passport";
 import { getManager } from "typeorm";
-import { ApolloError, AuthenticationError } from "apollo-server-express";
 import { verifyPassword } from "../utils/authUtils";
 import User, { roleTypes } from "../entities/User";
 import SocialLogins from "../entities/SocialLogins";
+import generateError, {
+  errorKeys,
+  generateApolloError,
+} from "../utils/ErrorFactory";
 
 passport.serializeUser((user: any, done): void => {
   done(null, user.id);
@@ -15,10 +18,10 @@ passport.serializeUser((user: any, done): void => {
 passport.deserializeUser(async (id: string, done) => {
   if (id) {
     const user = await User.findOne(id);
-    done(null, user);
-  } else {
-    throw new AuthenticationError("Failed to deserialize");
+    return done(null, user);
   }
+  return generateError(errorKeys.AUTH_FAIL_DESERIALIZE);
+  // throw new AuthenticationError("Failed to deserialize");
 });
 
 /// ////////////////// ///
@@ -34,7 +37,9 @@ passport.use(
     ) => {
       const user = await User.findOne({ where: { email } });
 
-      if (!user) return done(new Error("Cannot find the user"), null);
+      if (!user)
+        return done(generateApolloError(errorKeys.AUTH_NOT_FOUND), null);
+
       try {
         const isVerified = await verifyPassword(
           user.password as string,
@@ -43,9 +48,9 @@ passport.use(
         if (isVerified || user.role === roleTypes.GUEST)
           return done(null, user);
       } catch (err) {
-        return done(new ApolloError("Internal Server Error", "500"), null);
+        return done(generateApolloError(errorKeys.INTERNAL_SERVER_ERROR), null);
       }
-      return done(new AuthenticationError("no matching user"), null);
+      return done(generateApolloError(errorKeys.AUTH_NOT_MATCH), null);
     }
   )
 );
@@ -82,7 +87,7 @@ const socialCallback = async (
     const hasEmail = await User.findOne({ email });
 
     if (!socialUser && hasEmail) {
-      throw new ApolloError("User already exists", "401");
+      return generateError(errorKeys.AUTH_ALREADY_EXIST);
     }
 
     if (!socialUser) {
@@ -117,8 +122,7 @@ const socialCallback = async (
       done(null, user);
     }
   } catch (err) {
-    // TODO 에러핸들링
-    throw new ApolloError("Oooops! Something bad happened", "500");
+    return generateError(errorKeys.INTERNAL_SERVER_ERROR);
   }
 
   // TODO: invitation 확인 util 실행
@@ -126,6 +130,5 @@ const socialCallback = async (
 };
 
 passport.use(new GoogleStrategy(googleOptions, socialCallback));
-
 passport.use(new GitHubStrategy(githubOptions, socialCallback));
 export default passport;

--- a/src/utils/ErrorFactory.ts
+++ b/src/utils/ErrorFactory.ts
@@ -1,0 +1,75 @@
+import { ApolloError } from "apollo-server-express";
+import { FieldError } from "../resolvers/types/UserResponse";
+
+interface errorIFC {
+  [key: string]: {
+    code: string;
+    message: string;
+  };
+}
+
+const errorTypes: errorIFC = {
+  INTERNAL_SERVER_ERROR: {
+    code: "500",
+    message: "Internal Server Error 😵",
+  },
+  AUTH_NOT_FOUND: {
+    code: "401",
+    message: "User Not Found ❗️",
+  },
+  AUTH_ALREADY_EXIST: {
+    code: "404",
+    message: "User Already Existed 👀",
+  },
+  AUTH_NOT_MATCH: {
+    code: "402",
+    message: "Email or Password Not Match 🥑",
+  },
+  AUTH_NO_PERMISSION: {
+    code: "403",
+    message: "No Permission 🔫",
+  },
+  DATA_NOT_FOUND: {
+    code: "401",
+    message: "No Data 😕",
+  },
+  AUTH_FAIL_DESERIALIZE: {
+    code: "500",
+    message: "Failed to deserialize",
+  },
+};
+
+interface errorKey {
+  [key: string]: string;
+}
+
+export const errorKeys = {
+  ...Object.keys(errorTypes).reduce((obj: errorKey, key: string) => {
+    // eslint-disable-next-line
+    obj[key] = key;
+    return obj;
+  }, {}),
+};
+
+export type ErrorObject = {
+  message: string;
+  code: string;
+  field?: string;
+};
+
+export const generateApolloError = (type: keyof errorIFC): Error => {
+  const { code, message } = errorTypes[type];
+  return new ApolloError(message, code);
+};
+
+export const generateError = (
+  type: keyof errorIFC,
+  field?: string
+): FieldError => {
+  console.log("type : ", type);
+  console.log("errorTypes[type]:", errorTypes[type]);
+  const { code, message } = errorTypes[type];
+  return { message, code, field };
+};
+
+export default generateError;


### PR DESCRIPTION
[x] UserResponse의 Error Type을 수정

수정 전
```ts
@ObjectType()
export class UserResponse {
  @Field(() => [ApolloError], { nullable: true })
  errors?: ApolloError[];

  @Field(() => User, { nullable: true })
  user?: User;
}
```

수정 후
```
@ObjectType()
export class FieldError {
  @Field()
  code: string;

  @Field()
  message: string;

  @Field()
  field?: string;
}

@ObjectType()
export class UserResponse {
  @Field(() => User, { nullable: true })
  user?: User;

  @Field(() => FieldError, { nullable: true })
  error?: FieldError;
}
```


[x] Error Factory Utils 추가
사용 법:
```ts
generateError(type, field?): {code: string, message: string, field?: string}
```
type을 지정하면 해당 타입에 맞는 코드와 메시지, field명을 반환한다.