### PR TITLE
[RE-167] | fix getOrUpdateTask orderby createdAt of comment

### DIFF
--- a/src/entities/TaskNotification.ts
+++ b/src/entities/TaskNotification.ts
@@ -47,10 +47,9 @@ export default class TaskNotification extends BaseEntity {
   @JoinColumn({ name: "target_id" })
   target?: User;
 
-  @Field(() => Board, { nullable: true })
+  @Field(() => Board)
   @ManyToOne(() => Board, (board) => board.taskNotification, {
     onDelete: "CASCADE",
-    nullable: true,
   })
   @JoinColumn({ name: "status_id" })
   status: Board;


### PR DESCRIPTION
[x] task resolver에서 getTask 수정 : comment의 createdAt 순으로 정렬하는 쿼리로 수정
[x] task resolver에서 updateTask 수정 : comment의 createdAt 순으로 정렬하는 쿼리로 수정