### PR TITLE
[RE-270] | Adding cors option for apollo server

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 import "reflect-metadata";
 import express from "express";
 import session from "express-session";
-import cors from "cors";
+// import cors from "cors";
 import Redis from "ioredis";
 import connectRedis from "connect-redis";
 import { buildContext } from "graphql-passport";
@@ -12,31 +12,29 @@ import { ApolloServer } from "apollo-server-express";
 import dotenv from "dotenv-safe";
 import resolvers from "./resolvers";
 import { COOKIE_NAME, prod } from "./constants";
-
 // local
 // passport need env
 dotenv.config({ example: ".env" });
 /* eslint-disable */
 import passport from "./services/authService";
-
 // redis Setting (before apollo middleware)
 const RedisStore = connectRedis(session);
 export const redis = new Redis();
-
 const main = async () => {
   // orm Setting
   await createConnection();
-
   // express Setting
   const app = express();
-
-  app.use(
-    cors({
-      origin: "http://localhost:3000",
-      credentials: true,
-    })
-  );
-
+  const corsOptions = {
+    origin: "http://localhost:3000",
+    credentials: true,
+  };
+  // app.use(
+  //   cors({
+  //     origin: "http://localhost:3000",
+  //     credentials: true,
+  //   })
+  // );
   app.use(
     session({
       name: COOKIE_NAME,
@@ -56,20 +54,16 @@ const main = async () => {
       resave: false,
     })
   );
-
   app.use(passport.initialize());
   app.use(passport.session());
-
   app.get(
     "/auth/google",
     passport.authenticate("google", { scope: ["email", "profile"] })
   );
-
   app.get(
     "/auth/github",
     passport.authenticate("github", { scope: ["user:email"] })
   );
-
   app.get(
     "/auth/google/callback",
     passport.authenticate("google", {
@@ -77,7 +71,6 @@ const main = async () => {
       failureRedirect: "http://localhost:4000/graphql",
     })
   );
-
   app.get(
     "/auth/github/callback",
     passport.authenticate("github", {
@@ -85,7 +78,6 @@ const main = async () => {
       failureRedirect: "http://localhost:4000/graphql",
     })
   );
-
   // apollo Setting
   const apolloServer = new ApolloServer({
     schema: await buildSchema({
@@ -101,18 +93,15 @@ const main = async () => {
       },
     },
   });
-
   apolloServer.applyMiddleware({
     app,
-    cors: false,
+    cors: corsOptions,
   });
-
   const PORT = process.env.ENVIRONMENT || 4000;
   app.listen(PORT, () => {
     console.log(`🐶Retrievo Server is running : Port ${PORT}🐶`);
   });
 };
-
 main().catch((err) => {
   console.log(err);
 });

--- a/src/resolvers/types/UsernamePasswordInput.ts
+++ b/src/resolvers/types/UsernamePasswordInput.ts
@@ -10,6 +10,8 @@ export class UsernamePasswordInput {
 
   @Field()
   email: string;
-}
 
+  @Field({ nullable: true })
+  projectId?: string;
+}
 export default UsernamePasswordInput;


### PR DESCRIPTION
[ 에러 메시지 ] : Access to fetch at 'http://localhost:4000/graphql' from origin 'http://localhost:3000' has been blocked by CORS policy: The value of the 'Access-Control-Allow-Origin' header in the response must not be the wildcard '*' when the request's credentials mode is 'include'.

[해결 방법] : apollo server의 middleware options에 cors options을 추가함

```js

  const corsOptions = {
    origin: "http://localhost:3000",
    credentials: true,
  };

  apolloServer.applyMiddleware({
    app,
    cors: corsOptions,
  });

```